### PR TITLE
Add utf-8 charset meta tag

### DIFF
--- a/_includes/head.html
+++ b/_includes/head.html
@@ -1,4 +1,5 @@
 <head>
+  <meta charset="utf-8">
   <link rel="stylesheet" href="/css/main.css">
   <link rel="stylesheet" media="print" href="/css/print.css">
   <link href="https://fonts.googleapis.com/css?family=Anonymous+Pro|Pavanam" rel="stylesheet">


### PR DESCRIPTION
Some chars are distorted because of bad encoding.

![screenshot from 2017-08-02 09-23-03](https://user-images.githubusercontent.com/767671/28864528-be71df26-7764-11e7-808a-79f2e9b9a2c2.png)

Note the `âŽ`.

In local development, the jekyll server adds the `Content-Type	
"text/html; charset=utf-8"` header, so the problem is not visible there. That header is not added on the production site, so my browser is defaulting to `windows-1252` encoding.

I've added `<meta charset="utf-8">` into the `<head>`. This ought to fix broken chars appearing in the body of the page.

Unfortunately, I have been unable to reproduce this locally because of the aforementioned header.