### PR TITLE
Deleted word 'they'

### DIFF
--- a/_includes/ch/1.html
+++ b/_includes/ch/1.html
@@ -116,7 +116,7 @@ Interactive Elixir (1.5.0) - ⏎
   <div class='todo'>TODO: String image goes here.</div>
 
   <p>
-    The computer then takes in this string, interprets it and tells us how it interpreted the string. In this case, the computer is just parroting our sentence/string back to us. The computer can do a lot more than this, believe me. Computers wouldn't be very good if they all they did was parrot back to us.
+    The computer then takes in this string, interprets it and tells us how it interpreted the string. In this case, the computer is just parroting our sentence/string back to us. The computer can do a lot more than this, believe me. Computers wouldn't be very good if all they did was parrot back to us.
   </p>
 
   <p>


### PR DESCRIPTION
Sentence had extra word 'they'. Just think the sentence didn't intend to have the extra word. I deleted it.