### PR TITLE
set proper previous page for  chapter 18

### DIFF
--- a/18-automated-testing/index.html
+++ b/18-automated-testing/index.html
@@ -1,6 +1,6 @@
 ---
 layout: chapter
-previous_page: /17-introduction-to-mix
+previous_page: /17-mix-dependencies
 title: Automated testing
 ---
 


### PR DESCRIPTION
PROBLEM
Going back from chapter 18 takes the user to a non-existing "17-introduction-to-mix"

SOLUTION
Set back of chapter 18 to proper chapter 17.