### PR TITLE
Remove return value during history traversal

### DIFF
--- a/_includes/ch/13.html
+++ b/_includes/ch/13.html
@@ -121,8 +121,7 @@ iex(3)> %{age: "30ish", gender: "Female", name: "Izzy"}</code></pre>
       If we push the up-arrow again here, we'll get the same as line 3; the line we just had:
     </p>
 
-    <pre><code>iex(4)> izzy = %{age: "30ish", gender: "Female", name: "Izzy"}
-%{age: "30ish", gender: "Female", name: "Izzy"}</code></pre>
+    <pre><code>iex(4)> izzy = %{age: "30ish", gender: "Female", name: "Izzy"}</code></pre>
 
     <p>
       If we push it a second time, we'll get the same as line 2.
@@ -134,8 +133,7 @@ iex(3)> %{age: "30ish", gender: "Female", name: "Izzy"}</code></pre>
       If we push the down-arrow, we'll go back to line 3.
     </p>
 
-    <pre><code>iex(4)> izzy = %{age: "30ish", gender: "Female", name: "Izzy"}
-%{age: "30ish", gender: "Female", name: "Izzy"}</code></pre>
+    <pre><code>iex(4)> izzy = %{age: "30ish", gender: "Female", name: "Izzy"}</code></pre>
 
     <p>
       This is how we can navigate up and down, or back and forward (depending your viewpoint) through the history of


### PR DESCRIPTION
As we are just moving in the history using arrow keys, it is super confusing to always see some return value, although the iex line number remains the same. This is probably a c/p error from the original command.